### PR TITLE
Fix markdown formatting in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,12 @@
-#Office Puzzle Game
+# Office Puzzle Game
 
 A tile-based puzzle game with mechanics mimicking Valve's Portal. Implemented
     with JavaScript.
 
-###Developed by:###
+### Developed by: ###
 Jonathan Niehenke and CBC Tech Club Programming Group.
 
-###Contained files:###
+### Contained files: ###
 
 - Portal.html: The structure of elements within a page.
 - Portal.css: The rules defining how elements are displayed.
@@ -16,10 +16,10 @@ Jonathan Niehenke and CBC Tech Club Programming Group.
 - LICENSE.md - The License.
 - Readme.md - This file.
 
-###Requires:###
+### Requires: ###
 - A JavaScript enabled web browser.
 
-###How To:###
+### How To: ###
 1. Open the Portal.html in a compatible web browser.
 2. Within the page choose the PortalLevels.txt file.
 3. Navigate with the arrow keys, shoot portals with Ctrl and Shift and drop


### PR DESCRIPTION
The spacing in Readme.md was causing GitHub to fail to parse it as markdown formatting. This fixes the formatting and causes it to display properly.