### PR TITLE
Add instructions for including TileEngine submodule

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,8 @@ Jonathan Niehenke and CBC Tech Club Programming Group.
 - LICENSE.md - The License.
 - Readme.md - This file.
 
+**Note:** If you are cloning the repository, you will need to use ```git clone --recursive``` to clone the Tile Engine submodule simultaneously. If you aren't using git, you can also manually add the submodule from https://github.com/JonathanNiehenke/JS_TileEngine/ in place of the JS_TileEngine directory.
+
 ### Requires: ###
 - A JavaScript enabled web browser.
 


### PR DESCRIPTION
Even though we might switch to using another method of including the Tile Engine in the project (see #1 comment thread), instructions for how users will get the Tile Engine into their project will prevent confusion while submodules are still in use.